### PR TITLE
Get function returns defaultValue if key is not found

### DIFF
--- a/spine/support/utils/ObjectMap.hx
+++ b/spine/support/utils/ObjectMap.hx
@@ -17,7 +17,7 @@ abstract ObjectMap<K,V>(Map<Int,Array<Entry<K,V>>>) {
                 }
             }
         }
-        return null;
+        return defaultValue;
     }
 
     inline public function clear():Void {


### PR DESCRIPTION
Get function now returns defaultValue argument if key is not found. This causes AnimationStateDate.setDefaultMix() to have no effect.