### PR TITLE
fix for issues with HashLink target

### DIFF
--- a/spine/support/utils/JsonValue.hx
+++ b/spine/support/utils/JsonValue.hx
@@ -178,45 +178,45 @@ class JsonDynamic implements JsonValue {
 
 } //JsonDynamic
 
-class JsonChild implements JsonValue {
+class JsonChild extends JsonDynamic {
 
-    function toString() {
+    override function toString() {
         return 'JsonChild:'+data[index];
     }
 
     public var keys:Array<String>;
-    public var data:Array<Dynamic>;
     public var index:Int;
 
     public function new(data:Array<Dynamic>, index:Int, ?keys:Array<String>) {
-        this.data = data;
+        
+        super(data);
         this.index = index;
         this.keys = keys;
     }
     
-    public function has(key:String):Bool {
+    override public function has(key:String):Bool {
         return get(key) != null;
     }
 
-    public function require(key:String):JsonValue {
+    override public function require(key:String):JsonValue {
         return get(key);
     }
 
-    public function get(key:String):JsonValue {
+    override public function get(key:String):JsonValue {
         return Reflect.hasField(data[index], key) ? new JsonDynamic(Reflect.field(data[index], key)) : null;
     }
 
-    public function getChild(key:String):JsonValue {
+    override public function getChild(key:String):JsonValue {
         var item:Dynamic = Reflect.field(data[index], key);
         if (item == null) return null;
         else return new JsonDynamic(item).child;
     }
 
-    public function getString(key:String, defaultValue:String = null):String {
+    override public function getString(key:String, defaultValue:String = null):String {
         return Reflect.hasField(data[index], key) ? Reflect.field(data[index], key) : defaultValue;
     }
 
-    public function getFloat(key:Either<Int,String>, defaultValue:Float = 0):Float {
+    override public function getFloat(key:Either<Int,String>, defaultValue:Float = 0):Float {
         if (Std.is(key, Int)) {
             if (/*Std.is(data[index], Array) || */Std.is(data[index], std.Array)) {
                 return data[index][key];
@@ -229,36 +229,35 @@ class JsonChild implements JsonValue {
         }
     }
 
-    public function getInt(key:String, defaultValue:Int = 0):Int {
+    override public function getInt(key:String, defaultValue:Int = 0):Int {
         return Reflect.hasField(data[index], key) ? Reflect.field(data[index], key) : defaultValue;
     }
 
-    public function getBoolean(key:String, defaultValue:Bool = false):Bool {
+    override public function getBoolean(key:String, defaultValue:Bool = false):Bool {
         return Reflect.hasField(data[index], key) ? Reflect.field(data[index], key) : defaultValue;
     }
 
-    public function asString():String {
+    override public function asString():String {
         return data[index];
     }
 
-    public function asFloat():Float {
+    override public function asFloat():Float {
         return data[index];
     }
 
-    public function asInt():Int {
+    override public function asInt():Int {
         return data[index];
     }
 
-    public function isString():Bool {
+    override public function isString():Bool {
         return Std.is(data[index], String);
     }
 
-    public function isArray():Bool{
+    override public function isArray():Bool{
         return /*Std.is(data[index], Array) || */Std.is(data[index], std.Array);
     }
 
-    public var next(get,never):JsonValue;
-    function get_next():JsonValue {
+    override function get_next():JsonValue {
         if (index < data.length - 1) {
             return new JsonChild(data, index + 1, keys);
         }
@@ -267,18 +266,15 @@ class JsonChild implements JsonValue {
         }
     }
 
-    public var name(get,never):String;
-    function get_name():String {
+    override function get_name():String {
         return keys != null ? keys[index] : null;
     }
 
-    public var size(get,never):Int;
-    function get_size():Int {
+    override function get_size():Int {
         return data[index].length;
     }
 
-    public var child(get,never):JsonValue;
-    public function get_child():JsonValue {
+    override public function get_child():JsonValue {
         var item:Dynamic = data[index];
         if (item == null) return null;
         else if (/*Std.is(item, Array) || */Std.is(item, std.Array)) {
@@ -299,11 +295,11 @@ class JsonChild implements JsonValue {
         return null;
     }
 
-    public function asFloatArray():FloatArray {
+    override public function asFloatArray():FloatArray {
         return data[index];
     }
 
-    public function asShortArray():ShortArray {
+    override public function asShortArray():ShortArray {
         return data[index];
     }
 

--- a/spine/support/utils/JsonValue.hx
+++ b/spine/support/utils/JsonValue.hx
@@ -178,48 +178,48 @@ class JsonDynamic implements JsonValue {
 
 } //JsonDynamic
 
-class JsonChild extends JsonDynamic {
+class JsonChild implements JsonValue {
 
-    override function toString() {
+    function toString() {
         return 'JsonChild:'+data[index];
     }
 
     public var keys:Array<String>;
+    public var data:Array<Dynamic>;
     public var index:Int;
 
     public function new(data:Array<Dynamic>, index:Int, ?keys:Array<String>) {
-        
-        super(data);
+        this.data = data;
         this.index = index;
         this.keys = keys;
     }
     
-    override public function has(key:String):Bool {
+    public function has(key:String):Bool {
         return get(key) != null;
     }
 
-    override public function require(key:String):JsonValue {
+    public function require(key:String):JsonValue {
         return get(key);
     }
 
-    override public function get(key:String):JsonValue {
+    public function get(key:String):JsonValue {
         return Reflect.hasField(data[index], key) ? new JsonDynamic(Reflect.field(data[index], key)) : null;
     }
 
-    override public function getChild(key:String):JsonValue {
+    public function getChild(key:String):JsonValue {
         var item:Dynamic = Reflect.field(data[index], key);
         if (item == null) return null;
         else return new JsonDynamic(item).child;
     }
 
-    override public function getString(key:String, defaultValue:String = null):String {
+    public function getString(key:String, defaultValue:String = null):String {
         return Reflect.hasField(data[index], key) ? Reflect.field(data[index], key) : defaultValue;
     }
 
-    override public function getFloat(key:Either<Int,String>, defaultValue:Float = 0):Float {
+    public function getFloat(key:Either<Int,String>, defaultValue:Float = 0):Float {
         if (Std.is(key, Int)) {
-            if (/*Std.is(data[index], Array) || */Std.is(data[index], std.Array)) {
-                return data[index][key];
+            if (Std.is(data[index], std.Array)) {
+                return getByIndex()[key];
             } else {
                 return 0;
             }
@@ -229,35 +229,36 @@ class JsonChild extends JsonDynamic {
         }
     }
 
-    override public function getInt(key:String, defaultValue:Int = 0):Int {
+    public function getInt(key:String, defaultValue:Int = 0):Int {
         return Reflect.hasField(data[index], key) ? Reflect.field(data[index], key) : defaultValue;
     }
 
-    override public function getBoolean(key:String, defaultValue:Bool = false):Bool {
+    public function getBoolean(key:String, defaultValue:Bool = false):Bool {
         return Reflect.hasField(data[index], key) ? Reflect.field(data[index], key) : defaultValue;
     }
 
-    override public function asString():String {
+    public function asString():String {
         return data[index];
     }
 
-    override public function asFloat():Float {
+    public function asFloat():Float {
         return data[index];
     }
 
-    override public function asInt():Int {
+    public function asInt():Int {
         return data[index];
     }
 
-    override public function isString():Bool {
+    public function isString():Bool {
         return Std.is(data[index], String);
     }
 
-    override public function isArray():Bool{
-        return /*Std.is(data[index], Array) || */Std.is(data[index], std.Array);
+    public function isArray():Bool{
+        return Std.is(data[index], std.Array);
     }
 
-    override function get_next():JsonValue {
+    public var next(get,never):JsonValue;
+    function get_next():JsonValue {
         if (index < data.length - 1) {
             return new JsonChild(data, index + 1, keys);
         }
@@ -266,18 +267,21 @@ class JsonChild extends JsonDynamic {
         }
     }
 
-    override function get_name():String {
+    public var name(get,never):String;
+    function get_name():String {
         return keys != null ? keys[index] : null;
     }
 
-    override function get_size():Int {
-        return data[index].length;
+    public var size(get,never):Int;
+    function get_size():Int {
+        return getByIndex().length;
     }
 
-    override public function get_child():JsonValue {
+    public var child(get,never):JsonValue;
+    public function get_child():JsonValue {
         var item:Dynamic = data[index];
         if (item == null) return null;
-        else if (/*Std.is(item, Array) || */Std.is(item, std.Array)) {
+        else if (Std.is(item, std.Array)) {
             return new JsonChild(item, 0);
         }
         else {
@@ -295,12 +299,17 @@ class JsonChild extends JsonDynamic {
         return null;
     }
 
-    override public function asFloatArray():FloatArray {
+    public function asFloatArray():FloatArray {
         return data[index];
     }
 
-    override public function asShortArray():ShortArray {
+    public function asShortArray():ShortArray {
         return data[index];
+    }
+
+    private inline function getByIndex():Dynamic
+    {
+        return (data:std.Array<Dynamic>)[index];
     }
 
 } //JsonChild


### PR DESCRIPTION
Unfortunately i've found that there is issue with HashLink target (i've tried it with HashLink 1.7 and 1.8 versions). I think that problem lies in HashLink itself, but current spine-hx library doesn't work at all.
For some reason HashLink crashes when you import SkeletonJson class. After some investigation i've found that the crash is caused by JsonReader and JsonValue classes. I haven't isolated the root of this issue yet.
As a temporal workaround i had to make changes for `JsonValue` interface and classes which implement it.
I will report issue to HashLink repo as soon as i assemble simple projech which reproduces it.
Will keep you informed. Hope that it will be fixed soon.