### PR TITLE
* Strict casting for hashCode Int type in spine.Key;

### DIFF
--- a/spine/Skin.hx
+++ b/spine/Skin.hx
@@ -124,7 +124,7 @@ class Key {
         if (name == null) throw new IllegalArgumentException("name cannot be null.");
         this.slotIndex = slotIndex;
         this.name = name;
-        hashCode = 31 * (31 + name.getHashCode()) + slotIndex;
+        hashCode = Std.int(31 * (31 + name.getHashCode()) + slotIndex);
     }
 
     #if !spine_no_inline inline #end public function getHashCode():Int {

--- a/spine/support/utils/AttachmentMap.hx
+++ b/spine/support/utils/AttachmentMap.hx
@@ -56,10 +56,8 @@ abstract AttachmentMap(Map<Int,Array<Entry<Key,Attachment>>>) {
     public function entries() {
         var entries = [];
         for (entryList in this) {
-            if (entryList != null) { // Not sure why we need to check this in js :(
-                for (entry in entryList) {
-                    entries.push(entry);
-                }
+            for (entry in entryList) {
+                entries.push(entry);
             }
         }
         return entries;


### PR DESCRIPTION
Class `haxe.ds.IntMap` is using strict type casting to Int within `keys()` method. Generating keys as Int in method `set(slotIndex:Int, name:String):Void` of `spine.Key` class overflows Int limitation returning number higher than Int can represent. So we have large Float generated key and internal list of keys strictly limited by size. So searching and iteration through different keys value leads to unsuspected results.
Now `hashCode` is strictly typed as Int and all issues are gone.